### PR TITLE
Add rapidfuzz and nltk to install requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
     "pypdf>=4.2.0",
     "pytesseract>=0.3.13",
     "orjson>=3.11",
-    "pypdfium2==4.30.0"
+    "pypdfium2==4.30.0",
+    "rapidfuzz",
+    "nltk"
 ]
 
 [project.urls]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,3 +11,5 @@ scikit-learn>=1.5.0
 datasets>=3.0.0
 parsl==2025.3.10
 #accelerate==0.34.2 # causes condlicts
+rapidfuzz
+nltk


### PR DESCRIPTION
# Description
Add missing runtime dependencies for the Nougat parser. Importing `adaparse.parsers.nougat_parser.postprocessing` fails on fresh  installs because `rapidfuzz` isn’t installed (and `nltk` is also used). Declaring both in install requirements prevents AdaParse  0.1.4 from erroring immediately at import time.


### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #XX
- Fixes #XX

### Type of Change
<!--- Check which off the following types describe this PR --->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
Manual: `pip install -e .` and import path succeeds; previously failed with `ModuleNotFoundError: No module named 'rapidfuzz'`.

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [ ] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
